### PR TITLE
PDW 4751 Fix twilio cacerts

### DIFF
--- a/twilio/rest/resources/base.py
+++ b/twilio/rest/resources/base.py
@@ -37,23 +37,6 @@ class Response(object):
         self.url = url
 
 
-def get_cert_file():
-    """ Get the cert file location or bail """
-    # XXX - this currently fails test coverage because we don't actually go
-    # over the network anywhere. Might be good to have a test that stands up a
-    # local server and authenticates against it.
-    try:
-        # Apparently __file__ is not available in all places so wrapping this
-        # in a try/catch
-        current_path = os.path.realpath(__file__)
-        ca_cert_path = os.path.join(current_path, "..", "..", "..",
-                                    "conf", "cacert.pem")
-        return os.path.abspath(ca_cert_path)
-    except Exception:
-        # None means use the default system file
-        return None
-
-
 def make_request(method, url, params=None, data=None, headers=None,
                  cookies=None, files=None, auth=None, timeout=None,
                  allow_redirects=False, proxies=None):
@@ -75,7 +58,7 @@ def make_request(method, url, params=None, data=None, headers=None,
     """
     http = httplib2.Http(
         timeout=timeout,
-        ca_certs=get_cert_file(),
+        ca_certs=None,
         proxy_info=Connection.proxy_info(),
     )
     http.follow_redirects = allow_redirects

--- a/twilio/rest/resources/imports.py
+++ b/twilio/rest/resources/imports.py
@@ -2,7 +2,7 @@
 try:
     from urlparse import parse_qs
 except ImportError:
-    from cgi import parse_qs
+    from urllib.parse import parse_qs
 
 # json
 try:


### PR DESCRIPTION
# Fixes #

Use default `httplib2` cacert file instead of the build in one
